### PR TITLE
Updated test server

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,9 +1,10 @@
 {
     "recommendations": [
         "ms-dotnettools.csharp",
+		"ms-dotnettools.csdevkit",
         "editorconfig.editorconfig"
     ],
     "unwantedRecommendations": [
-        
+
     ]
 }

--- a/HotPotato.sln
+++ b/HotPotato.sln
@@ -49,6 +49,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HotPotato.Benchmark.Test", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HotPotato.NetFramework.Test", "test\HotPotato.NetFramework.Test\HotPotato.NetFramework.Test.csproj", "{7C9EFC5A-86CF-40C6-A33E-F7EA578A1992}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HotPotato.AspNetCore.Mvc.Testing", "src\HotPotato.AspNetCore.Mvc.Testing\HotPotato.AspNetCore.Mvc.Testing.csproj", "{08AFDDDC-6E90-4A7F-85A2-647FCE01182E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HotPotato.AspNetCore.Mvc.Testing.Test", "test\HotPotato.AspNetCore.Mvc.Testing.Test\HotPotato.AspNetCore.Mvc.Testing.Test.csproj", "{559AAFE6-3E34-43E6-899A-E90EB3A47A07}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -114,6 +118,14 @@ Global
 		{7C9EFC5A-86CF-40C6-A33E-F7EA578A1992}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{7C9EFC5A-86CF-40C6-A33E-F7EA578A1992}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7C9EFC5A-86CF-40C6-A33E-F7EA578A1992}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{08AFDDDC-6E90-4A7F-85A2-647FCE01182E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{08AFDDDC-6E90-4A7F-85A2-647FCE01182E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{08AFDDDC-6E90-4A7F-85A2-647FCE01182E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{08AFDDDC-6E90-4A7F-85A2-647FCE01182E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{559AAFE6-3E34-43E6-899A-E90EB3A47A07}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{559AAFE6-3E34-43E6-899A-E90EB3A47A07}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{559AAFE6-3E34-43E6-899A-E90EB3A47A07}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{559AAFE6-3E34-43E6-899A-E90EB3A47A07}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -128,6 +140,7 @@ Global
 		{06E2B4CF-A84A-4E9A-91F8-F2794F5B7B8A} = {18D73CFF-6ECA-4A0C-8A6A-97F84BC3E1C8}
 		{3AEFBAB9-D575-4876-8FA7-F89D4A14B4BE} = {18D73CFF-6ECA-4A0C-8A6A-97F84BC3E1C8}
 		{7C9EFC5A-86CF-40C6-A33E-F7EA578A1992} = {18D73CFF-6ECA-4A0C-8A6A-97F84BC3E1C8}
+		{559AAFE6-3E34-43E6-899A-E90EB3A47A07} = {18D73CFF-6ECA-4A0C-8A6A-97F84BC3E1C8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2836D304-9C78-41F8-9A22-517D86241D2C}

--- a/src/HotPotato.AspNetCore.Host/HotPotato.AspNetCore.Host.csproj
+++ b/src/HotPotato.AspNetCore.Host/HotPotato.AspNetCore.Host.csproj
@@ -56,8 +56,6 @@
 
   <ItemGroup>
     <Content Update="Properties\launchSettings.json">
-      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>Never</CopyToPublishDirectory>
     </Content>
   </ItemGroup>

--- a/src/HotPotato.AspNetCore.Middleware/HotPotatoMiddleware.cs
+++ b/src/HotPotato.AspNetCore.Middleware/HotPotatoMiddleware.cs
@@ -8,85 +8,40 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
+using HotPotato.Core.Models;
+using HotPotato.OpenApi;
+using HotPotato.Core.Processor;
+using HotPotato.Core.Http;
 
 namespace HotPotato.AspNetCore.Middleware
 {
 	public class HotPotatoMiddleware
 	{
-		private const string RemoteEndpointKey = "RemoteEndpoint";
 		private const string SpecLocationKey = "SpecLocation";
 
-		private readonly IProxy proxy;
-		private readonly ILogger log;
-		private readonly string remoteEndpoint;
-		private readonly RequestDelegate _next;
-
-		private static readonly HashSet<string> ProxyEndpoints =
-			new HashSet<string>
-			{
-				"/results",
-				"/cookies"
-			};
-
-		public HotPotatoMiddleware(RequestDelegate next, IProxy proxy, IConfiguration configuration, ILogger<HotPotatoMiddleware> log)
+		private IProcessor Processor { get; }
+		private ILogger Log { get; }
+		private RequestDelegate Next { get; }
+		
+		public HotPotatoMiddleware(RequestDelegate next, IConfiguration configuration, IProcessor processor, ILogger<HotPotatoMiddleware> log)
 		{
-			_ = proxy ?? throw Exceptions.ArgumentNull(nameof(proxy));
+			Next = next ?? throw Exceptions.ArgumentNull(nameof(next));
 			_ = configuration ?? throw Exceptions.ArgumentNull(nameof(configuration));
-			_ = log ?? throw Exceptions.ArgumentNull(nameof(log));
+			Processor = processor ?? throw Exceptions.ArgumentNull(nameof(processor));
+			Log = log ?? throw Exceptions.ArgumentNull(nameof(log));
 
-			_ = configuration[RemoteEndpointKey] ?? throw Exceptions.InvalidOperation("'RemoteEndpoint' is not defined");
 			_ = configuration[SpecLocationKey] ?? throw Exceptions.InvalidOperation("'SpecLocation' is not defined");
-
-			this.proxy = proxy;
-			this.log = log;
-			this.remoteEndpoint = configuration[RemoteEndpointKey];
-
-			log.LogInformation($"Forwarding to {remoteEndpoint}");
-			_next = next;
 		}
 
 		public async Task Invoke(HttpContext context)
 		{
-			if (ProxyEndpoints.Contains(context.Request.Path.Value))
-			{
-				await _next.Invoke(context);
-			}
-			else
-			{
-				try
-				{
-					this.log.LogDebug($"{context.Request.Method} {context.Request.Path}");
-					await this.proxy.ProcessAsync(this.remoteEndpoint, context.Request, context.Response);
-					this.log.LogDebug($"{context.Response.StatusCode} Length: {context.Response.ContentLength}");
-					this.log.LogDebug("--------------- Request End ---------------");
-				}
-				catch (HttpRequestException httpEx)
-				{
-					this.log.LogError(httpEx, "Failed to forward request. Remote endpoint may be down.");
-					context.Response.StatusCode = (int)HttpStatusCode.BadGateway;
-				}
-				catch (AggregateException agex)
-				{
-					SpecNotFoundException spex = agex.InnerException as SpecNotFoundException;
-					if (spex != null)
-					{
-						log.LogError(agex.InnerException, $"Failed to retrieve spec - please recheck SpecLocation and SpecToken.{Environment.NewLine}StatusCode: {(int)spex.Response.StatusCode}{Environment.NewLine}ReasonPhrase: {spex.Response.ReasonPhrase}");
-					}
-					else
-					{
-						//an example edge case would be a non-existent domain like https://raw.fakegithubusercontent.com/HylandSoftware/Hot-Potato/master/test/RawPotatoSpec.yaml
-						log.LogError(agex, "Exception thrown from an async call");
-					}
-					//we'll probably want to set to context.Reponse status code in the future,
-					//but for now trying to set it here will cause a "Response already started")
-				}
-				catch (Exception e)
-				{
-					//handle unknown exceptions
-					this.log.LogError(e, "Failed to forward request");
-					context.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
-				}
-			}
+			HttpRequest request = context.Request;
+			await Next(context);
+			HttpResponse response = context.Response;
+
+			HttpPair httpPair = new HttpPair(request.ToHotPotatoRequest(), response.ToHotPotatoResponse());
+
+			Processor.Process(httpPair);
 		}
 	}
 }

--- a/src/HotPotato.AspNetCore.Middleware/HotPotatoMiddleware.cs
+++ b/src/HotPotato.AspNetCore.Middleware/HotPotatoMiddleware.cs
@@ -22,7 +22,7 @@ namespace HotPotato.AspNetCore.Middleware
 		private IProcessor Processor { get; }
 		private ILogger Log { get; }
 		private RequestDelegate Next { get; }
-		
+
 		public HotPotatoMiddleware(RequestDelegate next, IConfiguration configuration, IProcessor processor, ILogger<HotPotatoMiddleware> log)
 		{
 			Next = next ?? throw Exceptions.ArgumentNull(nameof(next));
@@ -35,11 +35,11 @@ namespace HotPotato.AspNetCore.Middleware
 
 		public async Task Invoke(HttpContext context)
 		{
-			HttpRequest request = context.Request;
+			IHotPotatoRequest request = await context.Request.ToHotPotatoRequest();
 			await Next(context);
-			HttpResponse response = context.Response;
+			IHotPotatoResponse response = await context.Response.ToHotPotatoResponse();
 
-			HttpPair httpPair = new HttpPair(request.ToHotPotatoRequest(), response.ToHotPotatoResponse());
+			HttpPair httpPair = new HttpPair(request, response);
 
 			Processor.Process(httpPair);
 		}

--- a/src/HotPotato.AspNetCore.Mvc.Testing/HotPotato.AspNetCore.Mvc.Testing.csproj
+++ b/src/HotPotato.AspNetCore.Mvc.Testing/HotPotato.AspNetCore.Mvc.Testing.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.16" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\HotPotato.AspNetCore.Middleware\HotPotato.AspNetCore.Middleware.csproj" />
+    <ProjectReference Include="..\HotPotato.Extensions\HotPotato.Extensions.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/HotPotato.AspNetCore.Mvc.Testing/HotPotatoWebApplicationBuilder.cs
+++ b/src/HotPotato.AspNetCore.Mvc.Testing/HotPotatoWebApplicationBuilder.cs
@@ -4,20 +4,29 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Configuration;
+using System;
 
 namespace HotPotato.AspNetCore.Mvc.Testing;
 
 public class HotPotatoWebApplicationBuilder<TProgram>
 	: WebApplicationFactory<TProgram> where TProgram : class
 {
+	private readonly string specLocation;
+
+	public HotPotatoWebApplicationBuilder(string specLocation)
+	{
+		this.specLocation = specLocation ?? throw new ArgumentNullException(nameof(specLocation));
+	}
 
 	protected override void ConfigureWebHost(IWebHostBuilder builder)
 	{
 		builder.ConfigureServices(services =>
 		{
 			services.AddHotPotatoServices();
-			
+
 		});
+		builder.UseSetting("SpecLocation", this.specLocation);
 		builder.Configure(app =>
 		{
 			app.UseMiddleware<HotPotatoMiddleware>();

--- a/src/HotPotato.AspNetCore.Mvc.Testing/HotPotatoWebApplicationBuilder.cs
+++ b/src/HotPotato.AspNetCore.Mvc.Testing/HotPotatoWebApplicationBuilder.cs
@@ -3,6 +3,7 @@ using HotPotato.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 
 namespace HotPotato.AspNetCore.Mvc.Testing;
@@ -11,16 +12,27 @@ public class HotPotatoWebApplicationBuilder<TProgram>
 	: WebApplicationFactory<TProgram> where TProgram : class
 {
 
+	private readonly string specLocation;
+	public HotPotatoWebApplicationBuilder(string specLocation)
+	{
+		this.specLocation = specLocation ?? throw new ArgumentNullException(nameof(specLocation));
+	}
 	protected override void ConfigureWebHost(IWebHostBuilder builder)
 	{
 		builder.ConfigureServices(services =>
 		{
 			services.AddHotPotatoServices();
-			
+
 		});
 		builder.Configure(app =>
 		{
 			app.UseMiddleware<HotPotatoMiddleware>();
+		});
+		builder.ConfigureAppConfiguration(config => {
+			config.AddInMemoryCollection(new List<KeyValuePair<string, string>>
+			{
+				new KeyValuePair<string, string>("SpecLocation", this.specLocation)
+			});
 		});
 		base.ConfigureWebHost(builder);
 	}

--- a/src/HotPotato.AspNetCore.Mvc.Testing/HotPotatoWebApplicationBuilder.cs
+++ b/src/HotPotato.AspNetCore.Mvc.Testing/HotPotatoWebApplicationBuilder.cs
@@ -1,0 +1,38 @@
+﻿using HotPotato.AspNetCore.Middleware;
+using HotPotato.Extensions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Hosting;
+
+namespace HotPotato.AspNetCore.Mvc.Testing;
+
+public class HotPotatoWebApplicationBuilder<TProgram>
+	: WebApplicationFactory<TProgram> where TProgram : class
+{
+	public override IServiceProvider Services => base.Services;
+
+	protected override IHost CreateHost(IHostBuilder builder)
+	{
+		
+		return base.CreateHost(builder);
+	}
+
+	protected override void ConfigureWebHost(IWebHostBuilder builder)
+	{
+		builder.ConfigureServices(services =>
+		{
+			services.AddHotPotatoServices();
+			
+		});
+		builder.Configure(app =>
+		{
+			app.UseMiddleware<HotPotatoMiddleware>();
+		});
+		base.ConfigureWebHost(builder);
+	}
+	protected override void ConfigureClient(HttpClient client)
+	{
+		
+	}
+}

--- a/src/HotPotato.AspNetCore.Mvc.Testing/HotPotatoWebApplicationBuilder.cs
+++ b/src/HotPotato.AspNetCore.Mvc.Testing/HotPotatoWebApplicationBuilder.cs
@@ -10,13 +10,6 @@ namespace HotPotato.AspNetCore.Mvc.Testing;
 public class HotPotatoWebApplicationBuilder<TProgram>
 	: WebApplicationFactory<TProgram> where TProgram : class
 {
-	public override IServiceProvider Services => base.Services;
-
-	protected override IHost CreateHost(IHostBuilder builder)
-	{
-		
-		return base.CreateHost(builder);
-	}
 
 	protected override void ConfigureWebHost(IWebHostBuilder builder)
 	{
@@ -30,9 +23,5 @@ public class HotPotatoWebApplicationBuilder<TProgram>
 			app.UseMiddleware<HotPotatoMiddleware>();
 		});
 		base.ConfigureWebHost(builder);
-	}
-	protected override void ConfigureClient(HttpClient client)
-	{
-		
 	}
 }

--- a/src/HotPotato.Core/Http/Default/HotPotatoResponse.cs
+++ b/src/HotPotato.Core/Http/Default/HotPotatoResponse.cs
@@ -1,6 +1,8 @@
 
 using System.Net;
 using System.Net.Http.Headers;
+using System.Net.Mime;
+using System.Text;
 
 namespace HotPotato.Core.Http.Default
 {
@@ -10,6 +12,12 @@ namespace HotPotato.Core.Http.Default
 		{
 			this.StatusCode = statusCode;
 			this.Headers = headers;
+		}
+		public HotPotatoResponse(HttpStatusCode statusCode, HttpHeaders headers, byte[] content, string mediaType)
+			: this(statusCode, headers)
+		{
+			this.Content = content;
+			this.ContentType = new HttpContentType(mediaType);
 		}
 		public HotPotatoResponse(HttpStatusCode statusCode, HttpHeaders headers, byte[] content, MediaTypeHeaderValue contentType)
 			: this(statusCode, headers)

--- a/src/HotPotato.Core/Http/HttpExtensions.cs
+++ b/src/HotPotato.Core/Http/HttpExtensions.cs
@@ -1,5 +1,6 @@
 using HotPotato.Core.Http.Default;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.Extensions.Primitives;
 using System;
 using System.Collections.Generic;
@@ -150,7 +151,7 @@ namespace HotPotato.Core.Http
 		}
 
 		/// <summary>
-		/// Allow responses to be asynchronously processed by hot potato 
+		/// Allow responses to be asynchronously processed by hot potato
 		/// </summary>
 		/// <param name="this"></param>
 		/// <param name="response"></param>
@@ -220,21 +221,78 @@ namespace HotPotato.Core.Http
 			return encode.GetString(bodyContent);
 		}
 
-		public static IHotPotatoRequest ToHotPotatoRequest(this HttpRequest @this)
+		public static async Task<IHotPotatoRequest> ToHotPotatoRequest(this HttpRequest @this)
 		{
 			_ = @this ?? throw Exceptions.ArgumentNull(nameof(@this));
-			HotPotatoRequest request = (HotPotatoRequest)null;// new HotPotatoRequest(new HttpMethod(@this.Method), @this.);
 
+			HotPotatoRequest request = new HotPotatoRequest(new HttpMethod(@this.Method), new Uri(@this.GetDisplayUrl()));
+			if (@this.Headers != null && @this.Headers.Count > 0)
+			{
+				foreach (var item in @this.Headers)
+				{
+					if (!item.Key.Contains(customHeaderPrefix))
+					{
+						request.HttpHeaders.Add(item.Key, item.Value.ToArray());
+					}
+					else
+					{
+						request.CustomHeaders.Add(item.Key, item.Value.ToArray());
+					}
+				}
+			}
+			if (MethodsWithPayload.Contains(@this.Method.ToUpperInvariant()) && @this.Body != null)
+			{
+				using (MemoryStream stream = new MemoryStream())
+				{
+					await @this.Body.CopyToAsync(stream);
+					if (!string.IsNullOrEmpty(@this.ContentType))
+					{
+						//Sanitize here since System.Net.Http was throwing a format exception
+						//when sending POST/PUT requests with payloads through TestServer
+						@this.ContentType = @this.ContentType.Split(';')[0];
+					}
+					request.SetContent(stream.ToArray(), @this.ContentType);
+					// If we've read the body stream, seek back to the beginning
+					if(@this.Body.CanSeek)
+					{
+						@this.Body.Seek(0, SeekOrigin.Begin);
+					}
+				}
+			}
 
 			return request;
 		}
 
-		public static IHotPotatoResponse ToHotPotatoResponse(this HttpResponse @this)
+		public static async Task<IHotPotatoResponse> ToHotPotatoResponse(this HttpResponse @this)
 		{
 			_ = @this ?? throw Exceptions.ArgumentNull(nameof(@this));
-			HotPotatoResponse response = (HotPotatoResponse)null;//new HotPotatoResponse((HttpStatusCode)@this.StatusCode, );
 
-			return response;
+			HttpHeaders headers = new HttpHeaders();
+			if (@this.Headers != null)
+			{
+				foreach (var item in @this?.Headers)
+				{
+					headers.Add(item.Key.ToString(), item.Value.ToString());
+				}
+			}
+
+			if (@this.Body != null)
+			{
+				string contentType = @this.ContentType;
+
+				byte[] payload;
+				using(MemoryStream content = new MemoryStream())
+				{
+					await @this.Body.CopyToAsync(content);
+					payload = content.ToArray();
+				}
+
+				return new HotPotatoResponse((HttpStatusCode)@this.StatusCode, headers, payload, contentType);
+			}
+			else
+			{
+				return new HotPotatoResponse((HttpStatusCode)@this.StatusCode, headers, Array.Empty<byte>(), new MediaTypeHeaderValue("application/json"));
+			}
 		}
 	}
 }

--- a/src/HotPotato.Core/Http/HttpExtensions.cs
+++ b/src/HotPotato.Core/Http/HttpExtensions.cs
@@ -1,8 +1,10 @@
 using HotPotato.Core.Http.Default;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
@@ -216,6 +218,23 @@ namespace HotPotato.Core.Http
 					break;
 			}
 			return encode.GetString(bodyContent);
+		}
+
+		public static IHotPotatoRequest ToHotPotatoRequest(this HttpRequest @this)
+		{
+			_ = @this ?? throw Exceptions.ArgumentNull(nameof(@this));
+			HotPotatoRequest request = (HotPotatoRequest)null;// new HotPotatoRequest(new HttpMethod(@this.Method), @this.);
+
+
+			return request;
+		}
+
+		public static IHotPotatoResponse ToHotPotatoResponse(this HttpResponse @this)
+		{
+			_ = @this ?? throw Exceptions.ArgumentNull(nameof(@this));
+			HotPotatoResponse response = (HotPotatoResponse)null;//new HotPotatoResponse((HttpStatusCode)@this.StatusCode, );
+
+			return response;
 		}
 	}
 }

--- a/src/HotPotato.Extensions/ExtensionMethods.cs
+++ b/src/HotPotato.Extensions/ExtensionMethods.cs
@@ -4,11 +4,44 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.DependencyInjection;
+using HotPotato.Core.Proxy;
+using HotPotato.Core.Http;
+using HotPotato.OpenApi.SpecificationProvider;
+using HotPotato.OpenApi.Results;
+using HotPotato.Core.Processor;
+using Microsoft.AspNetCore.Http;
 
-namespace Microsoft.AspNetCore.TestHost
+namespace HotPotato.Extensions
 {
 	public static class ExtensionMethods
 	{
+		public static IHotPotatoRequest ToHotPotatoRequest(this HttpRequest @this)
+		{
+
+		}
+
+		public static IHotPotatoResponse ToHotPotatoResponse(this HttpResponse @this)
+		{
+
+		}
+
+		public static IServiceCollection AddHotPotatoForwardProxy(this IServiceCollection @this)
+		{
+			@this.AddScoped<IProxy, HotPotato.Core.Proxy.Default.Proxy>();
+			@this.AddScoped<IHotPotatoClient, HotPotatoClient>();
+			return @this;
+		}
+
+		public static IServiceCollection AddHotPotatoServices(this IServiceCollection @this)
+		{
+			@this.AddSingleton<ISpecificationProvider, SpecificationProvider>();
+			@this.AddSingleton<IResultCollector, ResultCollector>();
+
+			@this.AddTransient<IProcessor, Processor>();
+			return @this;
+		}
+
 		public static TestServer SetupHotPotatoServer(this TestServer apiServer, string testServerAddress)
 		{
 			HotPotatoClient apiClient = new HotPotatoClient(apiServer.CreateClient());

--- a/src/HotPotato.Extensions/ExtensionMethods.cs
+++ b/src/HotPotato.Extensions/ExtensionMethods.cs
@@ -11,21 +11,13 @@ using HotPotato.OpenApi.SpecificationProvider;
 using HotPotato.OpenApi.Results;
 using HotPotato.Core.Processor;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using HotPotato.OpenApi.Processor;
 
 namespace HotPotato.Extensions
 {
 	public static class ExtensionMethods
 	{
-		public static IHotPotatoRequest ToHotPotatoRequest(this HttpRequest @this)
-		{
-
-		}
-
-		public static IHotPotatoResponse ToHotPotatoResponse(this HttpResponse @this)
-		{
-
-		}
-
 		public static IServiceCollection AddHotPotatoForwardProxy(this IServiceCollection @this)
 		{
 			@this.AddScoped<IProxy, HotPotato.Core.Proxy.Default.Proxy>();

--- a/test/HotPotato.AspNetCore.Middleware.Test/HotPotato.AspNetCore.Middleware.Test.csproj
+++ b/test/HotPotato.AspNetCore.Middleware.Test/HotPotato.AspNetCore.Middleware.Test.csproj
@@ -37,8 +37,6 @@
 
   <ItemGroup>
     <Content Update="Properties\launchSettings.json">
-      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>Never</CopyToPublishDirectory>
     </Content>
   </ItemGroup>

--- a/test/HotPotato.AspNetCore.Middleware.Test/ProxyMiddlewareTest.cs
+++ b/test/HotPotato.AspNetCore.Middleware.Test/ProxyMiddlewareTest.cs
@@ -1,127 +1,127 @@
-using HotPotato.Core.Proxy;
-using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
-using Moq;
-using System;
-using System.Net;
-using System.Net.Http;
-using System.Threading.Tasks;
-using Xunit;
+//using HotPotato.Core.Proxy;
+//using Microsoft.AspNetCore.Http;
+//using Microsoft.Extensions.Configuration;
+//using Microsoft.Extensions.Logging;
+//using Moq;
+//using System;
+//using System.Net;
+//using System.Net.Http;
+//using System.Threading.Tasks;
+//using Xunit;
 
-namespace HotPotato.AspNetCore.Middleware
-{
-	public class HotPotatoMiddlewareTest
-	{
-		private const string RemoteEndpointKey = "RemoteEndpoint";
-		private const string AValidEndpoint = "http://foo";
-		private const string SpecLocationKey = "SpecLocation";
-		private const string AValidSpecLocation = "https://yukon.gold.potato.com/projects/TATO/repos/foo/raw/test/bar.yaml";
+//namespace HotPotato.AspNetCore.Middleware
+//{
+//	public class HotPotatoMiddlewareTest
+//	{
+//		private const string RemoteEndpointKey = "RemoteEndpoint";
+//		private const string AValidEndpoint = "http://foo";
+//		private const string SpecLocationKey = "SpecLocation";
+//		private const string AValidSpecLocation = "https://yukon.gold.potato.com/projects/TATO/repos/foo/raw/test/bar.yaml";
 
-		[Fact]
-		public void Constructor_NullProxy_Throws()
-		{
-			Assert.Throws<ArgumentNullException>("proxy", () => new HotPotatoMiddleware(null, null, Mock.Of<IConfiguration>(), Mock.Of<ILogger<HotPotatoMiddleware>>()));
-		}
+//		[Fact]
+//		public void Constructor_NullProxy_Throws()
+//		{
+//			Assert.Throws<ArgumentNullException>("proxy", () => new HotPotatoMiddleware(null, null, Mock.Of<IConfiguration>(), Mock.Of<ILogger<HotPotatoMiddleware>>()));
+//		}
 
-		[Fact]
-		public void Constructor_NullConfiguration_Throws()
-		{
-			Assert.Throws<ArgumentNullException>("configuration", () => new HotPotatoMiddleware(null, Mock.Of<IProxy>(), null, Mock.Of<ILogger<HotPotatoMiddleware>>()));
-		}
+//		[Fact]
+//		public void Constructor_NullConfiguration_Throws()
+//		{
+//			Assert.Throws<ArgumentNullException>("configuration", () => new HotPotatoMiddleware(null, Mock.Of<IProxy>(), null, Mock.Of<ILogger<HotPotatoMiddleware>>()));
+//		}
 
-		[Fact]
-		public void Constructor_NullLogger_Throws()
-		{
-			Assert.Throws<ArgumentNullException>("log", () => new HotPotatoMiddleware(null, Mock.Of<IProxy>(), Mock.Of<IConfiguration>(), null));
-		}
+//		[Fact]
+//		public void Constructor_NullLogger_Throws()
+//		{
+//			Assert.Throws<ArgumentNullException>("log", () => new HotPotatoMiddleware(null, Mock.Of<IProxy>(), Mock.Of<IConfiguration>(), null));
+//		}
 
-		[Fact]
-		public void Constructor_MissingRemoteEndpointKey_Throws()
-		{
-			Assert.Throws<InvalidOperationException>(() => new HotPotatoMiddleware(null, Mock.Of<IProxy>(), Mock.Of<IConfiguration>(), Mock.Of<ILogger<HotPotatoMiddleware>>()));
-		}
+//		[Fact]
+//		public void Constructor_MissingRemoteEndpointKey_Throws()
+//		{
+//			Assert.Throws<InvalidOperationException>(() => new HotPotatoMiddleware(null, Mock.Of<IProxy>(), Mock.Of<IConfiguration>(), Mock.Of<ILogger<HotPotatoMiddleware>>()));
+//		}
 
-		[Fact]
-		public void Constructor_MissingSpecLocationKey_Throws()
-		{
-			Mock<IConfiguration> configMock = new Mock<IConfiguration>();
-			configMock.SetupGet(x => x[RemoteEndpointKey]).Returns(AValidEndpoint);
-			Assert.Throws<InvalidOperationException>(() => new HotPotatoMiddleware(null, Mock.Of<IProxy>(), configMock.Object, Mock.Of<ILogger<HotPotatoMiddleware>>()));
-		}
+//		[Fact]
+//		public void Constructor_MissingSpecLocationKey_Throws()
+//		{
+//			Mock<IConfiguration> configMock = new Mock<IConfiguration>();
+//			configMock.SetupGet(x => x[RemoteEndpointKey]).Returns(AValidEndpoint);
+//			Assert.Throws<InvalidOperationException>(() => new HotPotatoMiddleware(null, Mock.Of<IProxy>(), configMock.Object, Mock.Of<ILogger<HotPotatoMiddleware>>()));
+//		}
 
-		[Fact]
-		public async Task Invoke_CallsProxy()
-		{
-			Mock<IProxy> proxyMock = new Mock<IProxy>();
-			Mock<IConfiguration> configMock = new Mock<IConfiguration>();
-			configMock.SetupGet(x => x[RemoteEndpointKey]).Returns(AValidEndpoint);
-			configMock.SetupGet(x => x[SpecLocationKey]).Returns(AValidSpecLocation);
-			Mock<HttpContext> contextMock = new Mock<HttpContext>();
-			var response = Mock.Of<HttpResponse>();
-			var request = Mock.Of<HttpRequest>();
-			contextMock.SetupGet(x => x.Request).Returns(request);
-			contextMock.SetupGet(x => x.Response).Returns(response);
+//		[Fact]
+//		public async Task Invoke_CallsProxy()
+//		{
+//			Mock<IProxy> proxyMock = new Mock<IProxy>();
+//			Mock<IConfiguration> configMock = new Mock<IConfiguration>();
+//			configMock.SetupGet(x => x[RemoteEndpointKey]).Returns(AValidEndpoint);
+//			configMock.SetupGet(x => x[SpecLocationKey]).Returns(AValidSpecLocation);
+//			Mock<HttpContext> contextMock = new Mock<HttpContext>();
+//			var response = Mock.Of<HttpResponse>();
+//			var request = Mock.Of<HttpRequest>();
+//			contextMock.SetupGet(x => x.Request).Returns(request);
+//			contextMock.SetupGet(x => x.Response).Returns(response);
 
-			HotPotatoMiddleware subject = new HotPotatoMiddleware(
-				null, 
-				proxyMock.Object, 
-				configMock.Object, 
-				Mock.Of<ILogger<HotPotatoMiddleware>>());
+//			HotPotatoMiddleware subject = new HotPotatoMiddleware(
+//				null, 
+//				proxyMock.Object, 
+//				configMock.Object, 
+//				Mock.Of<ILogger<HotPotatoMiddleware>>());
 
-			await subject.Invoke(contextMock.Object);
+//			await subject.Invoke(contextMock.Object);
 
-			proxyMock.Verify(x => x.ProcessAsync(AValidEndpoint, request, response));
-		}
+//			proxyMock.Verify(x => x.ProcessAsync(AValidEndpoint, request, response));
+//		}
 
-		[Fact]
-		public async Task Invoke_Throws_SetsInternalServerError()
-		{
-			Mock<IProxy> proxyMock = new Mock<IProxy>();
-			proxyMock.Setup(x => x.ProcessAsync(It.IsAny<string>(), It.IsAny<HttpRequest>(), It.IsAny<HttpResponse>()))
-				.Throws(new Exception("FAIL"));
-			Mock<IConfiguration> configMock = new Mock<IConfiguration>();
-			configMock.SetupGet(x => x[RemoteEndpointKey]).Returns(AValidEndpoint);
-			configMock.SetupGet(x => x[SpecLocationKey]).Returns(AValidSpecLocation);
-			Mock<ILogger<HotPotatoMiddleware>> loggerMock = new Mock<ILogger<HotPotatoMiddleware>>();
-			Mock<HttpContext> contextMock = new Mock<HttpContext>();
-			contextMock.SetupGet(x => x.Request).Returns(Mock.Of<HttpRequest>());
-			contextMock.SetupGet(x => x.Response).Returns(Mock.Of<HttpResponse>());
+//		[Fact]
+//		public async Task Invoke_Throws_SetsInternalServerError()
+//		{
+//			Mock<IProxy> proxyMock = new Mock<IProxy>();
+//			proxyMock.Setup(x => x.ProcessAsync(It.IsAny<string>(), It.IsAny<HttpRequest>(), It.IsAny<HttpResponse>()))
+//				.Throws(new Exception("FAIL"));
+//			Mock<IConfiguration> configMock = new Mock<IConfiguration>();
+//			configMock.SetupGet(x => x[RemoteEndpointKey]).Returns(AValidEndpoint);
+//			configMock.SetupGet(x => x[SpecLocationKey]).Returns(AValidSpecLocation);
+//			Mock<ILogger<HotPotatoMiddleware>> loggerMock = new Mock<ILogger<HotPotatoMiddleware>>();
+//			Mock<HttpContext> contextMock = new Mock<HttpContext>();
+//			contextMock.SetupGet(x => x.Request).Returns(Mock.Of<HttpRequest>());
+//			contextMock.SetupGet(x => x.Response).Returns(Mock.Of<HttpResponse>());
 
-			HotPotatoMiddleware subject = new HotPotatoMiddleware(
-				null,
-				proxyMock.Object,
-				configMock.Object,
-				loggerMock.Object);
+//			HotPotatoMiddleware subject = new HotPotatoMiddleware(
+//				null,
+//				proxyMock.Object,
+//				configMock.Object,
+//				loggerMock.Object);
 
-			await subject.Invoke(contextMock.Object);
+//			await subject.Invoke(contextMock.Object);
 
-			Assert.Equal((int)HttpStatusCode.InternalServerError, contextMock.Object.Response.StatusCode);
-		}
+//			Assert.Equal((int)HttpStatusCode.InternalServerError, contextMock.Object.Response.StatusCode);
+//		}
 
-		[Fact]
-		public async Task Invoke_ThrowsHttpRequestException_SetsBadGateway()
-		{
-			Mock<IProxy> proxyMock = new Mock<IProxy>();
-			proxyMock.Setup(x => x.ProcessAsync(It.IsAny<string>(), It.IsAny<HttpRequest>(), It.IsAny<HttpResponse>()))
-				.Throws(new HttpRequestException("FAIL"));
-			Mock<IConfiguration> configMock = new Mock<IConfiguration>();
-			configMock.SetupGet(x => x[RemoteEndpointKey]).Returns(AValidEndpoint);
-			configMock.SetupGet(x => x[SpecLocationKey]).Returns(AValidSpecLocation);
-			Mock<ILogger<HotPotatoMiddleware>> loggerMock = new Mock<ILogger<HotPotatoMiddleware>>();
-			Mock<HttpContext> contextMock = new Mock<HttpContext>();
-			contextMock.SetupGet(x => x.Request).Returns(Mock.Of<HttpRequest>());
-			contextMock.SetupGet(x => x.Response).Returns(Mock.Of<HttpResponse>());
+//		[Fact]
+//		public async Task Invoke_ThrowsHttpRequestException_SetsBadGateway()
+//		{
+//			Mock<IProxy> proxyMock = new Mock<IProxy>();
+//			proxyMock.Setup(x => x.ProcessAsync(It.IsAny<string>(), It.IsAny<HttpRequest>(), It.IsAny<HttpResponse>()))
+//				.Throws(new HttpRequestException("FAIL"));
+//			Mock<IConfiguration> configMock = new Mock<IConfiguration>();
+//			configMock.SetupGet(x => x[RemoteEndpointKey]).Returns(AValidEndpoint);
+//			configMock.SetupGet(x => x[SpecLocationKey]).Returns(AValidSpecLocation);
+//			Mock<ILogger<HotPotatoMiddleware>> loggerMock = new Mock<ILogger<HotPotatoMiddleware>>();
+//			Mock<HttpContext> contextMock = new Mock<HttpContext>();
+//			contextMock.SetupGet(x => x.Request).Returns(Mock.Of<HttpRequest>());
+//			contextMock.SetupGet(x => x.Response).Returns(Mock.Of<HttpResponse>());
 
-			HotPotatoMiddleware subject = new HotPotatoMiddleware(
-				null,
-				proxyMock.Object,
-				configMock.Object,
-				loggerMock.Object);
+//			HotPotatoMiddleware subject = new HotPotatoMiddleware(
+//				null,
+//				proxyMock.Object,
+//				configMock.Object,
+//				loggerMock.Object);
 
-			await subject.Invoke(contextMock.Object);
+//			await subject.Invoke(contextMock.Object);
 
-			Assert.Equal((int)HttpStatusCode.BadGateway, contextMock.Object.Response.StatusCode);
-		}
-	}
-}
+//			Assert.Equal((int)HttpStatusCode.BadGateway, contextMock.Object.Response.StatusCode);
+//		}
+//	}
+//}

--- a/test/HotPotato.AspNetCore.Mvc.Testing.Test/HotPotato.AspNetCore.Mvc.Testing.Test.csproj
+++ b/test/HotPotato.AspNetCore.Mvc.Testing.Test/HotPotato.AspNetCore.Mvc.Testing.Test.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\HotPotato.AspNetCore.Mvc.Testing\HotPotato.AspNetCore.Mvc.Testing.csproj" />
+    <ProjectReference Include="..\HotPotato.Api\HotPotato.Test.Api.csproj" />
+  </ItemGroup>
+</Project>

--- a/test/HotPotato.AspNetCore.Mvc.Testing.Test/UnitTest1.cs
+++ b/test/HotPotato.AspNetCore.Mvc.Testing.Test/UnitTest1.cs
@@ -1,0 +1,16 @@
+namespace HotPotato.AspNetCore.Mvc.Testing;
+
+public class Tests
+{
+    [SetUp]
+    public void Setup()
+    {
+    }
+
+    [Test]
+    public void Test1()
+    {
+        var subject = new HotPotatoWebApplicationBuilder<Test.Api.Startup>();
+    }
+}
+

--- a/test/HotPotato.AspNetCore.Mvc.Testing.Test/UnitTest1.cs
+++ b/test/HotPotato.AspNetCore.Mvc.Testing.Test/UnitTest1.cs
@@ -2,18 +2,18 @@ namespace HotPotato.AspNetCore.Mvc.Testing;
 
 public class Tests
 {
+    private const string specLocation = "https://raw.githubusercontent.com/HylandSoftware/Hot-Potato/master/test/RawPotatoSpec.yaml";
     [SetUp]
     public void Setup()
     {
     }
 
     [Test]
-    public void Test1()
+    public async Task Test1()
     {
-        var builder = new HotPotatoWebApplicationBuilder<Test.Api.Startup>();
+        var builder = new HotPotatoWebApplicationBuilder<Test.Api.Startup>(specLocation);
         var client = builder.CreateClient();
-        var response = client.GetAsync("/orders");
-        
+        var response = await client.GetAsync("/orders");
+
     }
 }
-

--- a/test/HotPotato.AspNetCore.Mvc.Testing.Test/UnitTest1.cs
+++ b/test/HotPotato.AspNetCore.Mvc.Testing.Test/UnitTest1.cs
@@ -10,7 +10,10 @@ public class Tests
     [Test]
     public void Test1()
     {
-        var subject = new HotPotatoWebApplicationBuilder<Test.Api.Startup>();
+        var builder = new HotPotatoWebApplicationBuilder<Test.Api.Startup>();
+        var client = builder.CreateClient();
+        var response = client.GetAsync("/orders");
+        
     }
 }
 

--- a/test/HotPotato.AspNetCore.Mvc.Testing.Test/UnitTest1.cs
+++ b/test/HotPotato.AspNetCore.Mvc.Testing.Test/UnitTest1.cs
@@ -8,12 +8,12 @@ public class Tests
     }
 
     [Test]
-    public void Test1()
+    public async Task Test1()
     {
-        var builder = new HotPotatoWebApplicationBuilder<Test.Api.Startup>();
+        var builder = new HotPotatoWebApplicationBuilder<Test.Api.Startup>("https://raw.githubusercontent.com/lambchop4prez/Hot-Potato/main/test/RawPotatoSpec.yaml");
         var client = builder.CreateClient();
-        var response = client.GetAsync("/orders");
-        
+        var response = await client.GetAsync("/orders");
+
     }
 }
 

--- a/test/HotPotato.AspNetCore.Mvc.Testing.Test/Usings.cs
+++ b/test/HotPotato.AspNetCore.Mvc.Testing.Test/Usings.cs
@@ -1,0 +1,2 @@
+global using NUnit.Framework;
+

--- a/test/HotPotato.E2E.Test/AutomaticDecompressionTest.cs
+++ b/test/HotPotato.E2E.Test/AutomaticDecompressionTest.cs
@@ -19,7 +19,7 @@ namespace HotPotato.E2E.Test
 	{
 		private IWebHost host;
         
-		private const string ApiLocation = "http://localhost:5000";
+		private const string ApiLocation = "http://localhost:5001";
 		private const string Endpoint = "/endpoint";
 		private const string ProxyEndpoint = "http://localhost:3232/endpoint";
 		private const string GetMethodCall = "GET";

--- a/test/HotPotato.NetFramework.Test/MiddlewareNetFrameworkTest.cs
+++ b/test/HotPotato.NetFramework.Test/MiddlewareNetFrameworkTest.cs
@@ -1,48 +1,48 @@
-using HotPotato.Core.Proxy;
-using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
-using Moq;
-using NUnit.Framework;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net;
-using System.Net.Http;
-using System.Text;
-using System.Threading.Tasks;
+//using HotPotato.Core.Proxy;
+//using Microsoft.AspNetCore.Http;
+//using Microsoft.Extensions.Configuration;
+//using Microsoft.Extensions.Logging;
+//using Moq;
+//using NUnit.Framework;
+//using System;
+//using System.Collections.Generic;
+//using System.Linq;
+//using System.Net;
+//using System.Net.Http;
+//using System.Text;
+//using System.Threading.Tasks;
 
-namespace HotPotato.AspNetCore.Middleware
-{
-	internal class MiddlewareNetFrameworkTest
-	{
-		private const string RemoteEndpointKey = "RemoteEndpoint";
-		private const string AValidEndpoint = "http://foo";
-		private const string SpecLocationKey = "SpecLocation";
-		private const string AValidSpecLocation = "https://yukon.gold.potato.com/projects/TATO/repos/foo/raw/test/bar.yaml";
+//namespace HotPotato.AspNetCore.Middleware
+//{
+//	internal class MiddlewareNetFrameworkTest
+//	{
+//		private const string RemoteEndpointKey = "RemoteEndpoint";
+//		private const string AValidEndpoint = "http://foo";
+//		private const string SpecLocationKey = "SpecLocation";
+//		private const string AValidSpecLocation = "https://yukon.gold.potato.com/projects/TATO/repos/foo/raw/test/bar.yaml";
 
-		[Test]
-		public async Task Invoke_CallsProxy()
-		{
-			Mock<IProxy> proxyMock = new Mock<IProxy>();
-			Mock<IConfiguration> configMock = new Mock<IConfiguration>();
-			configMock.SetupGet(x => x[RemoteEndpointKey]).Returns(AValidEndpoint);
-			configMock.SetupGet(x => x[SpecLocationKey]).Returns(AValidSpecLocation);
-			Mock<HttpContext> contextMock = new Mock<HttpContext>();
-			var response = Mock.Of<HttpResponse>();
-			var request = Mock.Of<HttpRequest>();
-			contextMock.SetupGet(x => x.Request).Returns(request);
-			contextMock.SetupGet(x => x.Response).Returns(response);
+//		[Test]
+//		public async Task Invoke_CallsProxy()
+//		{
+//			Mock<IProxy> proxyMock = new Mock<IProxy>();
+//			Mock<IConfiguration> configMock = new Mock<IConfiguration>();
+//			configMock.SetupGet(x => x[RemoteEndpointKey]).Returns(AValidEndpoint);
+//			configMock.SetupGet(x => x[SpecLocationKey]).Returns(AValidSpecLocation);
+//			Mock<HttpContext> contextMock = new Mock<HttpContext>();
+//			var response = Mock.Of<HttpResponse>();
+//			var request = Mock.Of<HttpRequest>();
+//			contextMock.SetupGet(x => x.Request).Returns(request);
+//			contextMock.SetupGet(x => x.Response).Returns(response);
 
-			HotPotatoMiddleware subject = new HotPotatoMiddleware(
-				null,
-				proxyMock.Object,
-				configMock.Object,
-				Mock.Of<ILogger<HotPotatoMiddleware>>());
+//			HotPotatoMiddleware subject = new HotPotatoMiddleware(
+//				null,
+//				proxyMock.Object,
+//				configMock.Object,
+//				Mock.Of<ILogger<HotPotatoMiddleware>>());
 
-			await subject.Invoke(contextMock.Object);
+//			await subject.Invoke(contextMock.Object);
 
-			proxyMock.Verify(x => x.ProcessAsync(AValidEndpoint, request, response));
-		}
-	}
-}
+//			proxyMock.Verify(x => x.ProcessAsync(AValidEndpoint, request, response));
+//		}
+//	}
+//}


### PR DESCRIPTION
This isn't quite building yet, but I wanted to show off progress and get some feedback.

This introduces a new `HotPotatoWebApplicationBuilder` which inherits from `WebApplicationFactory` which is the "new" .NET 6 way of doing integration tests. Basically, you use the generic type parameter `TProgram` to point to your Program class. It will then add the required Hot Potato Core services (Processor, SpecProvider, ResultCollector, OpenAPI stuff) and also configure a Middleware, which repurposes the HotPotato middleware into more of an HTTP spy (as I think we originally intended, but couldn't get the design down). The middleware gets the request, executes RequestDelegate, then gets the response and passes it to the Processor which _should_ populate the results collector.

I haven't run this yet as I haven't gotten it to build, just wanted to get this up.